### PR TITLE
🔒 Fix XSS in chat/killcam/scoreboard + scope quick-chat to the match

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -2,6 +2,11 @@ const socket = window.location.protocol === 'file:'
   ? io('http://localhost:3001')
   : io();
 
+// 🔒 Safety helpers — never let player-controlled text/colour reach innerHTML raw.
+// (mirrors escapeHtml in chat.js:431; used by the chat feed, killcam + scoreboard)
+function escapeHtml(s){ return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+function safeColor(c){ const s = String(c == null ? '' : c); return (/^#[0-9a-fA-F]{3,8}$/.test(s) || /^[a-zA-Z]{1,20}$/.test(s)) ? s : '#ffffff'; }
+
 // ── Weapon definitions ─────────────────────────────────────────────────────
 const WEAPONS = [
   {
@@ -1774,7 +1779,8 @@ function renderChatFeed() {
   feed.innerHTML = chatLog.map(line => {
     const age = (Date.now() - line.t) / 1000;
     const op = age > 6 ? Math.max(0, 1 - (age - 6) / 2) : 1;
-    return `<div style="background:rgba(0,0,0,0.6);padding:4px 9px;border-radius:5px;border-left:3px solid ${line.color};color:${line.color};opacity:${op};text-shadow:1px 1px 0 #000;">${line.text}</div>`;
+    const _col = safeColor(line.color), _txt = escapeHtml(line.text);
+    return `<div style="background:rgba(0,0,0,0.6);padding:4px 9px;border-radius:5px;border-left:3px solid ${_col};color:${_col};opacity:${op};text-shadow:1px 1px 0 #000;">${_txt}</div>`;
   }).join('');
 }
 function updateChatFeed() {
@@ -8952,7 +8958,7 @@ function openKillTheater(index) {
   ov.style.display = 'block';
   ov.innerHTML = `
     <div style="position:absolute;top:8px;left:50%;transform:translateX(-50%);color:#ffcc66;font-size:14px;letter-spacing:3px;background:rgba(0,0,0,0.6);padding:6px 16px;border-radius:6px;">
-      📹 KILL LOG · ${replay.victim} · ${replay.weapon}
+      📹 KILL LOG · ${escapeHtml(replay.victim)} · ${escapeHtml(replay.weapon)}
     </div>
     <button id="theater-close" style="position:absolute;top:8px;right:12px;pointer-events:all;background:#3a1a1a;color:#ff8888;border:1px solid #ff4444;padding:6px 14px;cursor:pointer;font-family:inherit;border-radius:4px;">✕ CLOSE</button>
     <button id="theater-rec" style="position:absolute;top:8px;right:120px;pointer-events:all;background:#1a3a1a;color:#88ff99;border:1px solid #44aa66;padding:6px 14px;cursor:pointer;font-family:inherit;border-radius:4px;">🎬 SAVE CLIP</button>
@@ -12500,7 +12506,7 @@ function showScoreboard(v) {
   Object.values(players).sort((a,b)=>b.kills-a.kills).forEach(p => {
     const tr = document.createElement('tr');
     if (p.id===myId) tr.className='me';
-    tr.innerHTML=`<td>${p.name}</td><td>${p.kills}</td><td>${p.deaths}</td><td>${p.hp}</td>`;
+    tr.innerHTML=`<td>${escapeHtml(p.name)}</td><td>${p.kills}</td><td>${p.deaths}</td><td>${p.hp}</td>`;
     tbody.appendChild(tr);
   });
 }

--- a/server.js
+++ b/server.js
@@ -1016,7 +1016,7 @@ io.on('connection', (socket) => {
     const now = Date.now();
     if (p._lastChatAt && now - p._lastChatAt < 800) return; // throttle to ~1/0.8s
     p._lastChatAt = now;
-    socket.broadcast.emit('chatLine', {
+    emitToMatch(p.matchId, 'chatLine', {
       id: socket.id,
       text: String(data.text || '').slice(0, 60),
       color: String(data.color || '#fff').slice(0, 12),


### PR DESCRIPTION
## TL;DR (English)

First off — this project is genuinely impressive. A solo-built browser FPS with ~117 weapons, 39 maps, bots, a killcam *theater*, a full shop economy, and an AI chat? That's a huge amount of working software. The kind of thing a lot of grown-up dev teams never finish. 

This PR is a small, focused safety fix. Right now, a player's **name** and **chat text** are inserted straight into the page's HTML. That means another player could type something clever into their name/chat that isn't just text — it could be **code that runs inside your browser**. That's called an **XSS** bug (Cross-Site Scripting). We fix it in 3 spots with a tiny `escapeHtml()` helper (one already exists in `chat.js:431`), lock down the chat color to a safe pattern, and stop quick-chat from leaking across matches.

It's intentionally **small and easy to review** — no behavior changes for normal players, just safer handling of text that comes from other people.

### What this PR changes

- [ ] **Add `escapeHtml()` to `public/game.js`** (mirroring the one in `public/chat.js:431`) so we have one helper to clean text before it touches `innerHTML`.
- [ ] **Fix chat feed XSS** — `public/game.js:1774-1777` (`renderChatFeed`): escape `line.text` before it goes into `innerHTML`.
- [ ] **Validate chat color** — `public/game.js:12578-12582` (`chatLine` socket handler): only accept a safe color (e.g. `#fff` / `#ffcc66` hex or a short allow-list), fall back to `#fff` otherwise. This stops CSS being injected through the `color` value.
- [ ] **Fix killcam XSS** — `public/game.js:8953-8955` (kill-log theater overlay): escape `replay.victim` and `replay.weapon` before `innerHTML`.
- [ ] **Fix scoreboard XSS** — `public/game.js:12503`: escape `p.name` before `innerHTML` (or build the row with `textContent`).
- [ ] **Scope quick-chat to the match** — `server.js:1019`: swap `socket.broadcast.emit('chatLine', …)` for `emitToMatch(p.matchId, 'chatLine', …)`, matching how `bulletFired` already works at `server.js:1042`.

### Why it matters (plain language)

When you do `element.innerHTML = "Hello " + someName`, the browser doesn't treat `someName` as *just letters* — it treats it as HTML. So if another player sets their name to something like `<img src=x onerror=...>`, that code runs **in your browser**, not theirs. With chat and the scoreboard, an attacker doesn't even need you to click anything — just *seeing* their name or message is enough to trigger it. The killcam one is sneaky: the bad name gets **saved** into your kill log (`localStorage`, `pvp_kill_log`) and fires every time you open the theater later.

The server currently only trims these strings to a max length (`server.js:968` for names, `server.js:1019-1024` for chat). Length-trimming is **not** the same as sanitizing — `"><img src=x onerror=alert(1)>` is short enough to slip right through. The real fix is on the client, at the moment we build the HTML.

### The fix approach

Two safe patterns, both fine:
1. **Escape, then interpolate** — run user text through `escapeHtml()` so `<`, `>`, `&`, `"` become harmless entities, *then* drop it into the template literal. Best when we want to keep the surrounding markup/styles.
2. **Use `textContent`** — for plain text like the scoreboard cells, set `cell.textContent = p.name` so the browser never parses it as HTML at all.

For the **color**, escaping isn't enough on its own (it's used inside a CSS `style="..."`), so we validate it against a pattern like `/^#[0-9a-fA-F]{3,8}$/` and fall back to `#fff` if it doesn't match.

For **quick-chat scoping**, `emitToMatch` keeps each match in its own bubble (same fix that solved the old cross-match bullet/6v6 issues). The sender's own echo is still filtered client-side by the existing `if (data.id === myId) return;` check at `game.js:12580`, so nothing breaks for the sender.

### Confirmed locations

| What | File:line | Tainted value |
|------|-----------|---------------|
| Chat feed `innerHTML` | `public/game.js:1774-1777` | `line.text`, `line.color` |
| Chat socket handler | `public/game.js:12578-12582` | `data.text`, `data.color` (from other players) |
| Killcam overlay `innerHTML` | `public/game.js:8953-8955` | `replay.victim`, `replay.weapon` |
| Scoreboard row `innerHTML` | `public/game.js:12503` | `p.name` |
| Quick-chat broadcast | `server.js:1019` | `socket.broadcast.emit` → should be `emitToMatch` |
| Existing helper to copy | `public/chat.js:431` | `escapeHtml()` reference impl |

### Out of scope (gentle note for later)

Per `CLAUDE.md`, passwords are stored in **plaintext** on purpose — that's a documented tradeoff for a hobby/learning project, and totally reasonable while you're building and experimenting. The reason it's worth flagging *here*: XSS + plaintext passwords is a spicy combo. If someone can run code in your browser, and there's a plaintext password sitting in `localStorage` (`pvp_user`, set at `game.js:17542`), they could potentially grab it. **Fixing the XSS in this PR already removes the dangerous half of that combo**, so you're in good shape. Hashing passwords (bcrypt/argon2) is a great "someday, if this goes production" upgrade — *not* something this PR needs to touch.

---

## 中文详细说明

先说一句：这个项目真的很牛。一个人独立做出来的浏览器 FPS，约 117 把武器、39 张地图、机器人 AI、击杀回放剧场（killcam theater）、完整的商店经济系统，还有 AI 聊天 —— 这个工作量非常大，很多成年人的开发团队都未必能做完。为你点赞 👏

这个 PR 是一个**小而专注**的安全修复，对正常玩家没有任何体验上的改动，只是更安全地处理「来自其他玩家的文字」。

### 这是什么问题？(XSS / 跨站脚本)

游戏里有几个地方，是这样往页面里塞内容的：

```js
element.innerHTML = "Hello " + 别人的名字;
```

问题在于：浏览器**不会**把「别人的名字」当成纯文字，而是当成 **HTML 代码**来解析。所以如果有个玩家把自己的名字改成类似 `<img src=x onerror=...>` 这样的东西，这段代码就会**在你的浏览器里运行**，而不是在他的浏览器里。这就叫 **XSS(跨站脚本攻击)**。

更麻烦的是：聊天和记分板这两个地方，攻击者**根本不需要你点任何东西** —— 你只要「看到」他的名字或消息，代码就触发了。而击杀回放那个更阴险：坏名字会被**存进**你的击杀日志(`localStorage` 里的 `pvp_kill_log`)，以后你每次打开剧场都会再触发一次。

服务器现在只是把这些字符串**截断到最大长度**(名字在 `server.js:968`，聊天在 `server.js:1019-1024`)。但「截断长度」**不等于**「消毒」—— 像 `"><img src=x onerror=alert(1)>` 这种攻击代码很短，照样能溜进来。真正该修的地方，是在客户端「拼 HTML 的那一刻」。

### 这个 PR 改了哪些地方

- [ ] **给 `public/game.js` 加一个 `escapeHtml()` 帮助函数**（照搬 `public/chat.js:431` 里已经有的那个），统一用它在文字进入 `innerHTML` 之前清理一遍。
- [ ] **修复聊天框 XSS** —— `public/game.js:1774-1777`（`renderChatFeed` 函数）：`line.text` 进 `innerHTML` 之前先转义。
- [ ] **校验聊天颜色** —— `public/game.js:12578-12582`（`chatLine` socket 处理器）：颜色只接受安全格式（比如 `#fff` 这种十六进制，或一个小白名单），不符合就回退到 `#fff`。这样能挡住通过 `color` 注入的 CSS。
- [ ] **修复击杀回放 XSS** —— `public/game.js:8953-8955`（killcam 剧场覆盖层）：`replay.victim` 和 `replay.weapon` 进 `innerHTML` 之前先转义。
- [ ] **修复记分板 XSS** —— `public/game.js:12503`：`p.name` 转义后再用（或者干脆用 `textContent` 来建这一行）。
- [ ] **把快捷聊天限制在同一局比赛内** —— `server.js:1019`：把 `socket.broadcast.emit('chatLine', …)` 换成 `emitToMatch(p.matchId, 'chatLine', …)`，跟 `server.js:1042` 那里 `bulletFired` 已经在用的写法保持一致。

### 修复思路

两种安全写法，都可以：
1. **先转义、再插值** —— 让用户文字过一遍 `escapeHtml()`，把 `<`、`>`、`&`、`"` 变成无害的实体字符，**然后**再放进模板字符串。想保留外面那层样式/标签时用这个。
2. **用 `textContent`** —— 像记分板那种纯文字格子，直接 `cell.textContent = p.name`，浏览器压根就不会把它当 HTML 解析。

**颜色**那个光转义还不够（它是放在 CSS 的 `style="..."` 里面用的），所以要用类似 `/^#[0-9a-fA-F]{3,8}$/` 的正则去校验，不匹配就回退成 `#fff`。

**快捷聊天的范围问题**：`emitToMatch` 能让每一局比赛各自独立（就是当年修好「子弹串场 / 陌生人一进来就变 6v6」那个老 bug 的同一招）。发送者自己的回声，仍然由 `game.js:12580` 那行已有的 `if (data.id === myId) return;` 在客户端过滤掉，所以对发送者来说不会有任何破坏。

### 已确认的位置（都来自核实过的证据）

| 内容 | 文件:行号 | 被污染的值 |
|------|-----------|------------|
| 聊天框 `innerHTML` | `public/game.js:1774-1777` | `line.text`、`line.color` |
| 聊天 socket 处理器 | `public/game.js:12578-12582` | `data.text`、`data.color`（来自其他玩家） |
| killcam 覆盖层 `innerHTML` | `public/game.js:8953-8955` | `replay.victim`、`replay.weapon` |
| 记分板行 `innerHTML` | `public/game.js:12503` | `p.name` |
| 快捷聊天广播 | `server.js:1019` | `socket.broadcast.emit` → 应改为 `emitToMatch` |
| 可参考的现成函数 | `public/chat.js:431` | `escapeHtml()` 实现 |

### 暂不处理（温和地留个「以后再说」）

根据 `CLAUDE.md`，密码是**故意明文存储**的 —— 这是你为这个业余/学习项目做的、有记录在案的取舍，在你边做边玩的阶段完全合理。之所以在这里**提一句**，是因为：XSS + 明文密码 是个有点危险的组合。如果有人能在你浏览器里跑代码，而 `localStorage` 里又躺着一个明文密码(`pvp_user`，在 `game.js:17542` 写入)，他就有可能把它偷走。**这个 PR 修好 XSS，其实已经把这个组合里最危险的那一半干掉了**，所以你已经稳了。给密码加哈希(bcrypt/argon2)是个很棒的「将来上线了再说」的升级 —— 这个 PR **不需要**碰它。

---

这个 PR 故意做得小、好审、好合。你已经把最难的部分(整个游戏)做出来了，现在养成「来自别人的文字，先消毒再上屏」这个习惯，就是从「能跑的游戏」走向「专业级代码」的一小步。继续加油，做得真的很棒！🚀